### PR TITLE
superset-patchup v0.4.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 REPO                      := onaio/superset
 STAGES                    := final
 SUPERSET_VERSION          := 1.5.0
-SUPERSET_KETCHUP_VERSION  := v0.3.0
+SUPERSET_KETCHUP_VERSION  := v0.4.0
 UPSTREAM_SUPERSET_VERSION := 1.5.0
 
 .PHONY: default clean clobber latest push


### PR DESCRIPTION
superset-patchup v0.4.0 makes the onadata provider name configurable